### PR TITLE
Modernize homepage with structured navigation and subpages

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,299 @@
+:root {
+  --color-background: #0e141b;
+  --color-surface: #18202b;
+  --color-surface-alt: #1f2936;
+  --color-accent: #4fc3f7;
+  --color-text: #f2f6fa;
+  --color-muted: #9fb3c8;
+  --font-heading: "Raleway", "Segoe UI", sans-serif;
+  --font-body: "Source Sans Pro", "Helvetica Neue", Arial, sans-serif;
+  --max-width: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: linear-gradient(135deg, var(--color-background), #141d29 45%, #0d1218 90%);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+header {
+  background: rgba(12, 18, 27, 0.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(79, 195, 247, 0.15);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.navbar {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+}
+
+.brand {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+}
+
+nav li {
+  position: relative;
+}
+
+nav a {
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color 0.2s ease;
+}
+
+nav li ul {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  background: var(--color-surface);
+  padding: 0.75rem 0;
+  border-radius: 0.5rem;
+  min-width: 220px;
+  display: none;
+  flex-direction: column;
+  box-shadow: 0 20px 45px rgba(7, 12, 19, 0.55);
+  border: 1px solid rgba(79, 195, 247, 0.1);
+}
+
+nav li ul a {
+  padding: 0.45rem 1rem;
+  width: 100%;
+  font-weight: 500;
+}
+
+nav li:hover > ul,
+nav li:focus-within > ul {
+  display: flex;
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+  margin-bottom: 4rem;
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.15;
+  margin: 0 0 1rem;
+}
+
+.hero p {
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  margin: 0 0 1.5rem;
+}
+
+.hero .cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.button {
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary {
+  background: var(--color-accent);
+  color: #051019;
+  box-shadow: 0 10px 30px rgba(79, 195, 247, 0.35);
+}
+
+.button-secondary {
+  border: 1px solid rgba(79, 195, 247, 0.35);
+  color: var(--color-text);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+}
+
+.section {
+  margin-bottom: 4.5rem;
+}
+
+.section h2 {
+  font-family: var(--font-heading);
+  margin-bottom: 1rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section p {
+  color: var(--color-muted);
+  max-width: 70ch;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(79, 195, 247, 0.12);
+  box-shadow: 0 12px 30px rgba(7, 12, 19, 0.35);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(79, 195, 247, 0.4);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.card p {
+  margin-bottom: 0;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tag {
+  background: rgba(79, 195, 247, 0.12);
+  color: var(--color-accent);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+footer {
+  background: rgba(8, 12, 18, 0.95);
+  border-top: 1px solid rgba(79, 195, 247, 0.15);
+  padding: 2.5rem 1.5rem;
+  color: var(--color-muted);
+}
+
+footer .footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: start;
+}
+
+footer a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+footer a:hover,
+footer a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  nav ul {
+    flex-direction: column;
+    background: var(--color-surface);
+    position: absolute;
+    right: 1.5rem;
+    top: 4.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(79, 195, 247, 0.15);
+    display: none;
+  }
+
+  nav ul.show {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    background: none;
+    border: 1px solid rgba(79, 195, 247, 0.4);
+    color: var(--color-text);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .nav-toggle span {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+  }
+
+  nav {
+    position: relative;
+  }
+
+  nav li ul {
+    position: static;
+    background: rgba(15, 22, 32, 0.9);
+    border: 1px solid rgba(79, 195, 247, 0.12);
+    margin-top: 0.5rem;
+  }
+}
+
+@media (min-width: 721px) {
+  .nav-toggle {
+    display: none;
+  }
+}

--- a/index.htm
+++ b/index.htm
@@ -1,39 +1,144 @@
 <!DOCTYPE html>
-<html>
+<html lang="da">
 <head>
-<title>Lars Sommer, Cyber security professional</title>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway">
-<style>
-body,h1 {font-family: "Raleway", sans-serif}
-body, html {height: 100%}
-.bgimg {
-  background-image: url('https://www.w3schools.com/w3images/forestbridge.jpg');
-  min-height: 100%;
-  background-position: center;
-  background-size: cover;
-  }
-</style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LASG.DK | Cyber- og informationssikkerhed</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
 </head>
 <body>
+  <header>
+    <div class="navbar">
+      <div class="brand">LASG.DK</div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="index.htm">Forside</a></li>
+          <li>
+            <a href="pages/cybersecurity/index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="pages/cybersecurity/services.html">Ydelser</a></li>
+              <li><a href="pages/cybersecurity/resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li>
+            <a href="pages/about/index.html">Om Lars</a>
+          </li>
+          <li>
+            <a href="pages/hobbies/tabletop/index.html">Fritid</a>
+            <ul>
+              <li><a href="tabletopgaming/boltaction.html">Bolt Action</a></li>
+              <li><a href="tabletopgaming/warhammer40k.html">Warhammer 40K</a></li>
+              <li><a href="tabletopgaming/heroquest.html">HeroQuest</a></li>
+            </ul>
+          </li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-<div class="bgimg w3-display-container w3-animate-opacity w3-text-white">
-  <div class="w3-display-topleft w3-padding-large w3-xlarge">
-    LASG.DK
-  </div>
-  <div class="w3-display-middle">
-    <h1 class="w3-jumbo w3-animate-top">Lars Sommer, <br />Cyber security professional</h1>
-    <hr class="w3-border-grey" style="margin:auto;width:40%">
-    <p class="w3-large w3-center"><a href="https://www.linkedin.com/in/larssommer4/">Visit my LinkedIn profile for CV and details</a></p>
-  </div>
-  <div class="w3-display-bottomleft w3-padding-large">
-    <a href="start.html">GOTO old homepage</a>
-  </div>
-</div>
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Strategisk cyber- og informationssikkerhed</h1>
+        <p>Jeg hjælper organisationer med at omsætte komplekse sikkerhedskrav til pragmatiske løsninger, der skaber tillid hos kunder, partnere og myndigheder. Her kan du lære mere om mit arbejde, mine ydelser og de fællesskaber jeg engagerer mig i.</p>
+        <div class="cta-group">
+          <a class="button button-primary" href="pages/cybersecurity/services.html">Se hvilke ydelser jeg tilbyder</a>
+          <a class="button button-secondary" href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">Kontakt mig via LinkedIn</a>
+        </div>
+      </div>
+      <div>
+        <div class="card">
+          <h3>Fokusområder</h3>
+          <p>Cyberstrategi, styring af risici, awareness programmer og implementering af sikkerhedsstandarder.</p>
+          <div class="tag-list">
+            <span class="tag">ISO 27001</span>
+            <span class="tag">NIS2</span>
+            <span class="tag">Governance</span>
+            <span class="tag">Incident response</span>
+          </div>
+        </div>
+      </div>
+    </section>
 
+    <section class="section">
+      <h2>Udvalgte initiativer</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Risikostyring med forretningen</h3>
+          <p>Jeg arbejder sammen med ledelsen om at definere beslutningsgange, der gør det muligt at reagere hurtigt på nye trusler, uden at innovationen går i stå.</p>
+        </article>
+        <article class="card">
+          <h3>Sikkerhedsarkitektur</h3>
+          <p>Fra cloudstrategi til zero trust-roadmaps – jeg binder teknologi, processer og mennesker sammen, så sikkerheden understøtter forretningen.</p>
+        </article>
+        <article class="card">
+          <h3>Kompetenceudvikling</h3>
+          <p>Jeg designer træningsforløb for udviklere, drift og ledere, så alle forstår deres rolle i organisationens forsvar.</p>
+        </article>
+      </div>
+    </section>
 
+    <section class="section">
+      <h2>Seneste artikler og ressourcer</h2>
+      <p>I undermapperne finder du uddybende beskrivelser af min tilgang, konkrete værktøjer og inspiration til dit eget arbejde med cybersikkerhed.</p>
+      <div class="grid">
+        <article class="card">
+          <h3>Metodebibliotek</h3>
+          <p>Opdag frameworks og skabeloner til governance, risikostyring og kontroller. Perfekt til teams, der skal i gang med NIS2.</p>
+          <a href="pages/cybersecurity/resources.html">Læs mere</a>
+        </article>
+        <article class="card">
+          <h3>Sådan samarbejder vi</h3>
+          <p>Fra de første workshops til implementering og opfølgning – her beskriver jeg processen, når vi udvikler sikkerhedsløsninger sammen.</p>
+          <a href="pages/cybersecurity/index.html">Læs mere</a>
+        </article>
+        <article class="card">
+          <h3>Fællesskaber</h3>
+          <p>Jeg deler også hobbyprojekter, herunder tabletop gaming, hvor taktik og samarbejde er i højsædet.</p>
+          <a href="pages/hobbies/tabletop/index.html">Besøg fællesskaberne</a>
+        </article>
+      </div>
+    </section>
+  </main>
 
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>LASG.DK</strong>
+        <p>Digitalt hjem for Lars Sommer. Strategisk rådgiver og praktiker inden for cyber- og informationssikkerhed.</p>
+      </div>
+      <div>
+        <strong>Kontakt</strong>
+        <p>Den hurtigste vej til mig er via <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a>. Her deler jeg også aktuelle indsigter.</p>
+      </div>
+      <div>
+        <strong>Flere ressourcer</strong>
+        <ul>
+          <li><a href="pages/cybersecurity/services.html">Ydelser</a></li>
+          <li><a href="pages/cybersecurity/resources.html">Ressourcer</a></li>
+          <li><a href="pages/hobbies/tabletop/index.html">Tabletop gaming</a></li>
+        </ul>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>

--- a/pages/about/index.html
+++ b/pages/about/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Om Lars | LASG.DK</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="navbar">
+      <div class="brand"><a href="../../index.htm">LASG.DK</a></div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="../../index.htm">Forside</a></li>
+          <li>
+            <a href="../cybersecurity/index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="../cybersecurity/services.html">Ydelser</a></li>
+              <li><a href="../cybersecurity/resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li><a href="index.html">Om Lars</a></li>
+          <li><a href="../hobbies/tabletop/index.html">Fritid</a></li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
+
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Mød Lars Sommer</h1>
+        <p>Jeg er rådgiver og leder inden for cyber- og informationssikkerhed med mere end 15 års erfaring fra internationale organisationer.</p>
+      </div>
+      <div class="card">
+        <h3>Kompetencer</h3>
+        <ul>
+          <li>Strategiudvikling og governance</li>
+          <li>Programledelse og transformation</li>
+          <li>Teknisk forståelse fra cloud til OT</li>
+          <li>Ledelse af tværfaglige teams</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Erfaring i korte træk</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Konsulent &amp; rådgiver</h3>
+          <p>Har hjulpet virksomheder med at bygge sikkerhedsorganisationer, etablere SOC-funktioner og implementere kontroller baseret på ISO 27001 og CIS Controls.</p>
+        </article>
+        <article class="card">
+          <h3>Ledelse</h3>
+          <p>Har stået i spidsen for sikkerhedsteams og programmer i vækstvirksomheder og større internationale koncerner.</p>
+        </article>
+        <article class="card">
+          <h3>Speaker &amp; community</h3>
+          <p>Deler jævnligt viden på konferencer og i netværk. Jeg brænder for at gøre cybersikkerhed jordnært og relevant.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Værdier</h2>
+      <ul>
+        <li><strong>Transparens:</strong> Beslutninger træffes på et oplyst grundlag og dokumenteres klart.</li>
+        <li><strong>Samarbejde:</strong> Succes opnås, når sikkerhed er et fælles ansvar.</li>
+        <li><strong>Fremdrift:</strong> Resultater skabes, når strategi og udførsel hænger sammen.</li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>Kontakt</h2>
+      <p>Du er velkommen til at forbinde på <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a> eller sende en mail til <a href="mailto:kontakt@lasg.dk">kontakt@lasg.dk</a>.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>Næste skridt</strong>
+        <ul>
+          <li><a href="../cybersecurity/index.html">Cybersecurity</a></li>
+          <li><a href="../cybersecurity/services.html">Ydelser</a></li>
+          <li><a href="../hobbies/tabletop/index.html">Tabletop gaming</a></li>
+        </ul>
+      </div>
+      <div>
+        <strong>Netværk</strong>
+        <p>Jeg engagerer mig i danske og internationale sikkerhedsnetværk for at dele erfaringer og lære nyt.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/cybersecurity/index.html
+++ b/pages/cybersecurity/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cybersecurity | LASG.DK</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="navbar">
+      <div class="brand"><a href="../../index.htm">LASG.DK</a></div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="../../index.htm">Forside</a></li>
+          <li>
+            <a href="index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="services.html">Ydelser</a></li>
+              <li><a href="resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li><a href="../about/index.html">Om Lars</a></li>
+          <li>
+            <a href="../hobbies/tabletop/index.html">Fritid</a>
+          </li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
+
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Cybersikkerhed med forretningen i centrum</h1>
+        <p>Jeg hjælper organisationer med at oversætte regulativer, kundekrav og teknisk kompleksitet til konkrete mål, roadmaps og indsatser. Her kan du læse om, hvordan vi strukturerer samarbejdet.</p>
+      </div>
+      <div class="card">
+        <h3>Sådan arbejder jeg</h3>
+        <ul>
+          <li>Strategiske dialoger på ledelsesniveau</li>
+          <li>Workshops og analyse med tekniske teams</li>
+          <li>Implementering og løbende opfølgning</li>
+          <li>Forankring via træning og klare beslutningsveje</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Tre faser i samarbejdet</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>1. Fokus og baseline</h3>
+          <p>Vi afdækker den aktuelle situation, herunder governance, kontroller og teknisk landskab. Resultatet er en fælles forståelse af risici og modenhed.</p>
+        </article>
+        <article class="card">
+          <h3>2. Design og prioritering</h3>
+          <p>På baggrund af baselinen udvikler vi målarkitektur, policies og handlingsplaner, der er realistiske og understøtter forretningens tempo.</p>
+        </article>
+        <article class="card">
+          <h3>3. Implementering</h3>
+          <p>Vi omsætter planerne til praksis via projekter, træning og ledelsesrapportering. Jeg sikrer momentum og dokumentation.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Relaterede undermapper</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Ydelser</h3>
+          <p>Detaljeret oversigt over rådgivning, interim-roller og workshops.</p>
+          <a href="services.html">Udforsk ydelserne</a>
+        </article>
+        <article class="card">
+          <h3>Ressourcer</h3>
+          <p>Skabeloner, checklister og inspiration til dine egne sikkerhedsinitiativer.</p>
+          <a href="resources.html">Find værktøjer</a>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>Kontakt</strong>
+        <p>Vil du høre mere? Skriv via <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a>.</p>
+      </div>
+      <div>
+        <strong>Flere sider</strong>
+        <ul>
+          <li><a href="services.html">Ydelser</a></li>
+          <li><a href="resources.html">Ressourcer</a></li>
+          <li><a href="../hobbies/tabletop/index.html">Tabletop gaming</a></li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/cybersecurity/resources.html
+++ b/pages/cybersecurity/resources.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ressourcer | LASG.DK</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="navbar">
+      <div class="brand"><a href="../../index.htm">LASG.DK</a></div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="../../index.htm">Forside</a></li>
+          <li>
+            <a href="index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="services.html">Ydelser</a></li>
+              <li><a href="resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li><a href="../about/index.html">Om Lars</a></li>
+          <li><a href="../hobbies/tabletop/index.html">Fritid</a></li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
+
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Ressourcer og værktøjer</h1>
+        <p>Her samler jeg skabeloner, checklist­er og inspiration til dig, der arbejder med cyber- og informationssikkerhed. Alt kan frit benyttes og tilpasses.</p>
+      </div>
+      <div class="card">
+        <h3>Opdateringer</h3>
+        <p>Jeg opdaterer siden løbende med nye materialer. Gem siden som bogmærke eller følg med på LinkedIn for notifikationer.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Skabeloner</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Governance charter</h3>
+          <p>En kompakt skabelon til at beskrive roller, ansvar og beslutningsgange for sikkerhedsorganisationen.</p>
+          <p><strong>Format:</strong> PowerPoint &amp; PDF</p>
+        </article>
+        <article class="card">
+          <h3>Risikovurdering light</h3>
+          <p>Excel-model med scoringer, heatmap og forslag til mitigering. Ideel til små og mellemstore projekter.</p>
+        </article>
+        <article class="card">
+          <h3>Incident log</h3>
+          <p>Skema til at dokumentere hændelser, læring og status. Kan bruges både af drift og ledelse.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Artikler og guides</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Guide: Klar til NIS2</h3>
+          <p>En praktisk introduktion til kravene og hvordan du bygger et roadmap uden at drukne organisationen i administration.</p>
+        </article>
+        <article class="card">
+          <h3>Checklist: Leverandørstyring</h3>
+          <p>Oversigt over krav til tredjepartsaftaler, due diligence og løbende evaluering.</p>
+        </article>
+        <article class="card">
+          <h3>FAQ: Zero Trust</h3>
+          <p>Besvarer de mest almindelige spørgsmål om arkitektur, teknologi og forretningsværdi.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Sådan bruger du materialet</h2>
+      <p>Materialet er tænkt som udgangspunkt for dialog i din egen organisation. Tilpas indholdet til jeres processer, og kontakt mig gerne, hvis du ønsker sparring omkring implementering.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>Relaterede sider</strong>
+        <ul>
+          <li><a href="index.html">Cybersecurity</a></li>
+          <li><a href="services.html">Ydelser</a></li>
+          <li><a href="../about/index.html">Om Lars</a></li>
+        </ul>
+      </div>
+      <div>
+        <strong>Følg med</strong>
+        <p>Nye ressourcer annonceres på <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a>.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/cybersecurity/services.html
+++ b/pages/cybersecurity/services.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ydelser | LASG.DK</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="navbar">
+      <div class="brand"><a href="../../index.htm">LASG.DK</a></div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="../../index.htm">Forside</a></li>
+          <li>
+            <a href="index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="services.html">Ydelser</a></li>
+              <li><a href="resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li><a href="../about/index.html">Om Lars</a></li>
+          <li><a href="../hobbies/tabletop/index.html">Fritid</a></li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
+
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Ydelser og samarbejdsform</h1>
+        <p>Fra kortvarige afklaringer til længerevarende engagements. Jeg sammensætter forløb, der matcher organisationens modenhed og ambitioner.</p>
+        <a class="button button-primary" href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">Book en introduktionssamtale</a>
+      </div>
+      <div class="card">
+        <h3>Brancher</h3>
+        <p>Erfaring fra finans, energi, produktion, tech og offentlige myndigheder. Fællesnævneren er høje krav til compliance, tilgængelighed og tillid.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Rådgivningsområder</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Strategisk rådgivning</h3>
+          <p>Udvikling af sikkerhedsstrategier, målbilleder og governance strukturer. Jeg hjælper dig med at sikre budgetter og forankring.</p>
+        </article>
+        <article class="card">
+          <h3>Program- og projektledelse</h3>
+          <p>Eksekvering af sikkerhedsprojekter, fra identitet &amp; adgang til SOC-optimering. Fokus på fremdrift, leverancer og dokumentation.</p>
+        </article>
+        <article class="card">
+          <h3>Interim CISO / sikkerhedsleder</h3>
+          <p>Mid­lertidig ledelse af sikkerhedsfunktionen. Ideelt ved omstrukturering, rekruttering eller særlige compliance-krav.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Workshops og formater</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Kickstart NIS2</h3>
+          <p>To-dages workshop, der vurderer NIS2-parathed og leverer en prioriteret handlingsplan.</p>
+        </article>
+        <article class="card">
+          <h3>Incident rehearsal</h3>
+          <p>Bordøvelser for ledelsen og krisestaben. Vi tester beredskab, kommunikation og beslutningsgange.</p>
+        </article>
+        <article class="card">
+          <h3>Sikkerhedskultur</h3>
+          <p>Design af awareness-programmer, måling af effekt og opbygning af ambassadørnetværk.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Sådan kommer vi i gang</h2>
+      <ol>
+        <li>Introduktionsmøde hvor vi afstemmer udfordringer, succeskriterier og tidshorisont.</li>
+        <li>Forslag til samarbejde, herunder team-sammensætning, leverancer og estimater.</li>
+        <li>Opstart med en fælles plan og klare kontaktpunkter.</li>
+      </ol>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>Andre sider</strong>
+        <ul>
+          <li><a href="index.html">Cybersecurity</a></li>
+          <li><a href="resources.html">Ressourcer</a></li>
+          <li><a href="../about/index.html">Om Lars</a></li>
+        </ul>
+      </div>
+      <div>
+        <strong>Kontakt</strong>
+        <p>Skriv via <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a> eller send en invitation til et møde.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/hobbies/tabletop/index.html
+++ b/pages/hobbies/tabletop/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabletop gaming | LASG.DK</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;600;700&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../assets/css/main.css">
+</head>
+<body>
+  <header>
+    <div class="navbar">
+      <div class="brand"><a href="../../../index.htm">LASG.DK</a></div>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+      </button>
+      <nav aria-label="Hovednavigation">
+        <ul id="primary-navigation">
+          <li><a href="../../../index.htm">Forside</a></li>
+          <li>
+            <a href="../../cybersecurity/index.html">Cybersecurity</a>
+            <ul>
+              <li><a href="../../cybersecurity/services.html">Ydelser</a></li>
+              <li><a href="../../cybersecurity/resources.html">Ressourcer</a></li>
+            </ul>
+          </li>
+          <li><a href="../../about/index.html">Om Lars</a></li>
+          <li><a href="index.html">Fritid</a></li>
+          <li><a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.querySelector('.nav-toggle');
+      const menu = document.querySelector('#primary-navigation');
+      if (toggle && menu) {
+        toggle.addEventListener('click', () => {
+          const isOpen = menu.classList.toggle('show');
+          toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+      }
+    });
+  </script>
+
+  <main>
+    <section class="hero">
+      <div>
+        <h1>Tabletop gaming &amp; fællesskab</h1>
+        <p>Når tiden tillader det, dykker jeg ned i strategiske brætspil og miniaturekampe. Her deler jeg erfaringer, scenarier og tips til både nye og erfarne spillere.</p>
+      </div>
+      <div class="card">
+        <h3>Hvorfor tabletop?</h3>
+        <p>Det kombinerer strategi, historiefortælling og socialt samvær – præcis som god cybersikkerhed kræver koordinering og samarbejde.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Artikler og guider</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Bolt Action</h3>
+          <p>Taktiske WWII-scenarier, maleterreng og husregler til at skabe spænding.</p>
+          <a href="../../../tabletopgaming/boltaction.html">Læs mere</a>
+        </article>
+        <article class="card">
+          <h3>Warhammer 40.000</h3>
+          <p>Hærbygning, kampstrategi og hobbyprojekter fra grimdark-universet.</p>
+          <a href="../../../tabletopgaming/warhammer40k.html">Læs mere</a>
+        </article>
+        <article class="card">
+          <h3>HeroQuest</h3>
+          <p>Klassisk dungeon crawling med moderne tweaks og familievenlige scenarier.</p>
+          <a href="../../../tabletopgaming/heroquest.html">Læs mere</a>
+        </article>
+        <article class="card">
+          <h3>Warlords of Erehwon</h3>
+          <p>Fantasiarmeer, kampagner og hjemmelavede missioner.</p>
+          <a href="../../../tabletopgaming/warlords.html">Læs mere</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Del gerne</h2>
+      <p>Har du egne scenarier eller tips, så skriv til mig. Jeg deler gerne gæsteindlæg og billeder fra fælles spil.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <strong>Andre interesser</strong>
+        <ul>
+          <li><a href="../../cybersecurity/index.html">Cybersikkerhed</a></li>
+          <li><a href="../../about/index.html">Om Lars</a></li>
+          <li><a href="../../../tabletopgaming/tom.htm">Gamle arkiver</a></li>
+        </ul>
+      </div>
+      <div>
+        <strong>Kontakt</strong>
+        <p>Del dine idéer via <a href="https://www.linkedin.com/in/larssommer4/" target="_blank" rel="noopener">LinkedIn</a>.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the landing page with a modern layout that introduces services and links into new content areas
- add a reusable design system in `assets/css/main.css` and responsive navigation with dropdowns
- create dedicated pages for cybersecurity focus areas, services, resources, about, and tabletop hobbies within subfolders

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68dce0081f388331846ecb37d64b9ad2)